### PR TITLE
feat: enable fat link-time optimization on release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "treels"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,20 @@
 [package]
 name = "treels"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Pia <pia.cosneau@gmail.com>"]
-description = "Display your files in a recursive manner"
-readme = "README.md"
-license = "MIT"
 repository = "https://github.com/PiaCOS/treels"
 keywords = ["cli"]
 categories = ["command-line-utilities"]
+description = "Display your files in a recursive manner"
+readme = "README.md"
+license = "MIT"
 
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
+
+
+[profile.release]
+lto = true
+codegen-units = 1


### PR DESCRIPTION
Added a release profile with fat [LTO](https://doc.rust-lang.org/rustc/codegen-options/index.html#lto).

This reduce the build size:
- From: 1011.6KiB
- To: 781.1KiB

On: 
- macOS 15.1.1
- cargo 1.81.0 (2dbb1af80 2024-08-20)  